### PR TITLE
fix bug

### DIFF
--- a/server/src/server_season.rs
+++ b/server/src/server_season.rs
@@ -90,7 +90,17 @@ impl DataBase
         )?;
 
         self.conn.execute(
-            &format!("create table matches as select * from matches{} where 0", season_number),
+            "create table if not exists matches (
+                id              integer primary key autoincrement,
+                epoch           bigint not null,
+                elo_diff        integer,
+                winner_elo      float,
+                loser_elo       float,
+                winner          integer,
+                loser           integer,
+                foreign key(winner) references users(id),
+                foreign key(loser) references users(id)
+                )",
             NO_PARAMS,
         )?;
 


### PR DESCRIPTION
# Changes: :dog2: 
* Fix bug :beetle: 
The previous line 
```sql
create table matches as select * from matches{} where 0
```
Only copies the _type_ info of the schema not _all_  info, so the first line in the table is:
 ```sql
 id INT,
```
Instead of:
```sql
 id integer primary key autoincrement,
```
meaning when creating a new match the id field will be NULL
:facepalm: