### PR TITLE
New users are soft inactive, and can create superusers from server flags

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -398,11 +398,30 @@ fn spawn_season_checker(data: Arc<Mutex<DataBase>>)
     });
 }
 
+
+fn handle_args(data: &Arc<Mutex<DataBase>>)
+{
+    let vec = std::env::args().collect::<Vec<String>>();
+    match vec.as_slice()
+    {
+        [_, flag, name] =>
+        {
+            // Make user admin
+            if flag.as_str() == "-a"
+            {
+                data.lock().unwrap().create_superuser(name.clone()).unwrap();
+            }
+        }
+        _ => {}
+    }
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()>
 {
     let data = Arc::new(Mutex::new(DataBase::new(DATABASE_FILE)));
     spawn_season_checker(data.clone());
+    handle_args(&data);
 
     let server = HttpServer::new(move || {
         App::new()


### PR DESCRIPTION
# Changes :dog2: 
* Can create admin users from the server executable: :building_construction: :construction: :construction_worker_man: 
```bash
./<exec> -a <username>
```
The above example will create a new superuser/admin with the name `<username>`
* New users are default soft inactive. This way they don't show up on the scoreboard before registering a match. :bookmark_tabs: 