### PR TITLE
add: cancel season support

### DIFF
--- a/server/server/src/process.rs
+++ b/server/server/src/process.rs
@@ -24,7 +24,7 @@ fn get_ars(data: &Arc<Mutex<DataBase>>) -> (bool, i64, u32)
 fn start_new_season(data: &Arc<Mutex<DataBase>>)
 {
     let s = data.lock().expect("Getting mutex");
-    s.end_season().expect("Endig season");
+    s.end_season(true).expect("Endig season");
     s.start_new_season().expect("starting new season");
 }
 

--- a/server/server/src/server.rs
+++ b/server/server/src/server.rs
@@ -1721,7 +1721,7 @@ mod test
         s.register_match(user1.clone(), user2.clone(), token1.clone()).unwrap();
         s.respond_to_match(1, ACCEPT_REQUEST, token2.clone()).unwrap();
 
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
         s.start_new_season().unwrap();
 
 

--- a/server/server/src/server_rollback.rs
+++ b/server/server/src/server_rollback.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use elo::EloRank;
-use rusqlite::{named_params, Connection, NO_PARAMS};
+use rusqlite::{named_params, Connection};
 use server_core::types::ServerResult;
 
 use super::{r#match::Match, server::DataBase};

--- a/server/server/src/server_season.rs
+++ b/server/server/src/server_season.rs
@@ -10,9 +10,9 @@ use crate::GET_OR_CREATE_DB_VAR;
 
 impl DataBase
 {
-    pub fn end_season(&self) -> ServerResult<()>
+    pub fn end_season(&self, stop_season: bool) -> ServerResult<()>
     {
-        self._end_season()
+        self._end_season(stop_season)
     }
 
     pub fn start_new_season(&self) -> ServerResult<()>
@@ -71,18 +71,29 @@ impl DataBase
 // ~ end season functions
 impl DataBase
 {
-    fn _end_season(&self) -> ServerResult<()>
+    fn _end_season(&self, stop_season: bool) -> ServerResult<()>
     {
         // Only award badges if there were a season
         if let Some(season) = self.get_latest_season()?
         {
             if self.get_is_season()?
             {
-                for (i, user) in self.get_users()?.into_iter().take(NUM_SEASON_PRIZES).enumerate()
+                if stop_season
                 {
-                    self.award_badge(i as i64, season.id, user.id)?;
+                    for (i, user) in
+                        self.get_users()?.into_iter().take(NUM_SEASON_PRIZES).enumerate()
+                    {
+                        self.award_badge(i as i64, season.id, user.id)?;
+                    }
+                    self.archive_match_history(season.id)?;
                 }
-                self.archive_match_history(season.id)?;
+                else
+                {
+                    // We wanted to cancel the season, in this case we don't award
+                    // badges, _and_ we delete the season, idea is to use this
+                    // to cancel a season that was not ment to starto
+                    self.delete_season(season.id)?;
+                }
                 self.clear_matches()?;
                 self.clear_notifications()?;
                 self.reset_elos()?;
@@ -114,6 +125,12 @@ impl DataBase
         )?;
         Ok(())
     }
+
+    fn delete_season(&self, season_id: i64) -> ServerResult<()>
+    {
+        self.conn.execute("delete from seasons where id = ?1", params![season_id])?;
+        Ok(())
+    }
 }
 
 
@@ -137,9 +154,12 @@ impl DataBase
 
     fn create_new_season(&self) -> ServerResult<()>
     {
-        self.conn.execute("insert into seasons (start_epoch) values (?1)", params![
-            Utc::now().timestamp_millis()
-        ])?;
+        let next_season = self.get_latest_season_number().unwrap_or(0) + 1;
+        self.conn
+            .execute("insert into seasons (id, start_epoch) values (?1, ?2)", params![
+                next_season,
+                Utc::now().timestamp_millis()
+            ])?;
         Ok(())
     }
 }
@@ -254,7 +274,7 @@ mod test
         s.register_match(lars.clone(), siv.clone(), token_siv.clone())
             .expect("Creating match");
         let notification_count_before = get_table_size(&s, "match_notification");
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
         let notification_count_after = get_table_size(&s, "match_notification");
 
         s.register_match(lars.clone(), siv.clone(), token_siv.clone())
@@ -288,7 +308,7 @@ mod test
         s.register_match(lars.clone(), siv.clone(), token_siv.clone())
             .expect("Creating match");
         respond_to_match(&s, lars.as_str(), 1);
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
 
         let badge_len = s.get_user(&lars).unwrap().badges.len();
         let old_matches_len = get_table_size(&s, "old_matches");
@@ -326,13 +346,13 @@ mod test
         let s = DataBase::new(db_file);
 
         s.start_new_season().unwrap();
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
 
         s.start_new_season().unwrap();
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
 
         s.start_new_season().unwrap();
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
 
         let mut stmt = s.conn.prepare("select count(*) from seasons").unwrap();
         let count = stmt
@@ -367,7 +387,7 @@ mod test
             (s.get_user(&siv).unwrap().elo, s.get_user(&mark).unwrap().elo);
 
         s.start_new_season().unwrap();
-        s.end_season().unwrap();
+        s.end_season(true).unwrap();
 
         let (s_elo_new, m_elo_new) =
             (s.get_user(&siv).unwrap().elo, s.get_user(&mark).unwrap().elo);
@@ -401,12 +421,12 @@ mod test
         create_user(&s, "Ella");
 
         s.start_new_season().expect("Staring first season");
-        s.end_season().expect("ending first season");
+        s.end_season(true).expect("ending first season");
 
         let users1 = s.get_users().expect("Getting users");
         // Do this scheme to check that a new season gave _new_ awards
         s.start_new_season().expect("Starting season");
-        s.end_season().expect("Ending season");
+        s.end_season(true).expect("Ending season");
 
         let users2 = s.get_users().expect("Getting users");
 
@@ -431,7 +451,7 @@ mod test
         let s = DataBase::new(db_file);
         create_user(&s, "Sivert");
 
-        s.end_season().expect("ending season");
+        s.end_season(true).expect("ending season");
 
         let users = s.get_users().expect("Getting users");
         std::fs::remove_file(db_file).expect("Removing file tempH");
@@ -450,5 +470,29 @@ mod test
         let start = s.get_season_start();
         std::fs::remove_file(db_file).expect("Removing file tempH");
         assert_eq!(time, start.unwrap())
+    }
+
+    #[test]
+    fn test_can_cancel_season()
+    {
+        let db_file = "tempL2.db";
+        let s = DataBase::new(db_file);
+        create_user(&s, "Sivert");
+        let m = create_user(&s, "Markus");
+
+        s.start_new_season().unwrap();
+        s.register_match("Markus".to_string(), "Sivert".to_string(), m).unwrap();
+        respond_to_match(&s, "Sivert", 1);
+        let first_season = s.get_latest_season().unwrap();
+
+        s.end_season(false).unwrap();
+        let season_after_cancel = s.get_latest_season().unwrap();
+        let user = s.get_user(&"Sivert".to_string()).unwrap();
+
+        std::fs::remove_file(db_file).expect("Removing file tempH");
+        assert!(first_season.is_some());
+        assert!(season_after_cancel.is_none());
+        assert!(user.elo == 1500.);
+        assert!(user.badges.len() == 0);
     }
 }

--- a/server/server_core/src/constants/mod.rs
+++ b/server/server_core/src/constants/mod.rs
@@ -10,6 +10,7 @@ const DECLINE_REQUEST: u8 = 2;
 
 pub const STOP_SEASON: i64 = -1;
 pub const START_SEASON: i64 = -2;
+pub const CANCEL_SEASON: i64 = -3;
 
 pub const N_SEASON_ID: u32 = 1;
 pub const IS_SEASON_ID: u32 = 2;

--- a/website/src/api/AdminApi.js
+++ b/website/src/api/AdminApi.js
@@ -46,6 +46,11 @@ export const startSeason = () =>
     token: localStorage.getItem('token'),
   })
 
+export const cancelSeason = () =>
+    BaseApi.post('cancel_season', {
+        token: localStorage.getItem('token'),
+    })
+
 export const executeSql = (str) =>
   BaseApi.post('admin/execute-sql', {
     token: localStorage.getItem('token'),

--- a/website/src/pages/admin-page/edit-season/EditSeason.js
+++ b/website/src/pages/admin-page/edit-season/EditSeason.js
@@ -55,7 +55,6 @@ class EditSeason extends Component {
         this.setState({})
       })
       .catch((error) => console.warn(error))
-    this.setState({})
   }
 
   start() {
@@ -65,7 +64,6 @@ class EditSeason extends Component {
         this.setState({})
       })
       .catch((error) => console.warn(error))
-    this.setState({})
   }
 
   cancel() {
@@ -75,7 +73,6 @@ class EditSeason extends Component {
         this.setState({})
       })
       .catch((error) => console.warn(error))
-    this.setState({})
   }
 
   submit() {
@@ -85,7 +82,6 @@ class EditSeason extends Component {
         this.setState({})
       })
       .catch((error) => console.warn(error))
-    this.setState({})
   }
 
   render() {
@@ -106,7 +102,10 @@ class EditSeason extends Component {
               <Button placeholder="Submit" callback={() => this.submit()} />
             </div>
             <br />
-            <Button placeholder="Cancel Season" callback={() => this.cancel()} />
+            <Button
+              placeholder="Cancel Season"
+              callback={() => this.cancel()}
+            />
             <Button placeholder="Stop Season" callback={() => this.stop()} />
             <Button placeholder="Start Season" callback={() => this.start()} />
             <br />

--- a/website/src/pages/admin-page/edit-season/EditSeason.js
+++ b/website/src/pages/admin-page/edit-season/EditSeason.js
@@ -68,6 +68,16 @@ class EditSeason extends Component {
     this.setState({})
   }
 
+  cancel() {
+    AdminApi.cancelSeason()
+      .then(() => {
+        this.successLabel = 'Canceled the season'
+        this.setState({})
+      })
+      .catch((error) => console.warn(error))
+    this.setState({})
+  }
+
   submit() {
     AdminApi.setSeasonLength(this.seasonLength)
       .then(() => {
@@ -96,6 +106,7 @@ class EditSeason extends Component {
               <Button placeholder="Submit" callback={() => this.submit()} />
             </div>
             <br />
+            <Button placeholder="Cancel Season" callback={() => this.cancel()} />
             <Button placeholder="Stop Season" callback={() => this.stop()} />
             <Button placeholder="Start Season" callback={() => this.start()} />
             <br />


### PR DESCRIPTION
# Changes: :malawi: 
* Can cancel seasons
What is the use case?
Imagine it's june 1st and you want to start an off season (since it's summer), but damn, the server started season 6, stopping the season would end season 6, but you want to destroy season 6.  

Now you can just cancel the season. This is yeets the existence of that season, I.e 
  * resets elos
  * clears matches and notifications
  * deletes the season from the DB