### PR TITLE
fix issue with wrong assets path -- AGAIN

### DIFF
--- a/server/server/src/tournament.rs
+++ b/server/server/src/tournament.rs
@@ -254,8 +254,7 @@ impl DataBase
     fn create_image_prize(&self, image: String, tournament: i64) -> ServerResult<i64>
     {
         let image_name = format!("{}/{}.png", TOURNAMENT_BADGES_PATH, tournament);
-        let mut file =
-            std::fs::File::create(&format!("assets/{}", image_name)).expect("creating file");
+        let mut file = std::fs::File::create(&image_name).expect("creating file");
 
         let bin: Vec<&str> = image.as_str().splitn(2, ",").collect();
         let bin = base64::decode(bin[1]).unwrap();

--- a/server/server_core/src/constants/mod.rs
+++ b/server/server_core/src/constants/mod.rs
@@ -23,4 +23,11 @@ pub const USER_ROLE_SOFT_INACTIVE: u8 = 1 << 4;
 
 pub const DATABASE_FILE: &'static str = "db.db";
 
-pub const TOURNAMENT_BADGES_PATH: &'static str = "tournament_badges";
+pub const TOURNAMENT_BADGES_PATH: &'static str = if cfg!(debug_assertions)
+{
+    "assets/tournament_badges"
+}
+else
+{
+    "./db/assets/tournament_badges"
+};


### PR DESCRIPTION
# changes: :dog2:
Basically, locally, you are running the server from the same folder as where 'assets' is laying, but on the 
TD server it is run from home.
